### PR TITLE
62 connect soufiles to word table

### DIFF
--- a/src/actions/soundfileUrl.ts
+++ b/src/actions/soundfileUrl.ts
@@ -1,0 +1,25 @@
+"use server";
+
+// Genererar presignerade URL:er för ljudfiler som finns i S3-bucketen.
+import { GetObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { s3Client, S3_BUCKET_NAME } from "@/lib/s3Client";
+
+export async function generateS3Urls(filenames: string[]) {
+    const urls: Record<string, string> = {};
+
+    for (const filename of filenames) {
+        try {
+            const command = new GetObjectCommand({
+                Bucket: S3_BUCKET_NAME,
+                Key: `${filename}`,
+            });
+            // Presignerad URL gäller i 1 timme
+            urls[filename] = await getSignedUrl(s3Client, command, { expiresIn: 3600 });
+        } catch (error) {
+            console.error(`Failed to generate URL for ${filename}:`, error);
+        }
+    }
+
+    return urls;
+}

--- a/src/app/adminView/page.tsx
+++ b/src/app/adminView/page.tsx
@@ -6,6 +6,7 @@ import ImportExcelSection from "@/components/Admin/ImportExcelSection";
 import Link from "next/link";
 import { GetAllDialectwords } from "@/actions/dialectwords";
 import { getActiveUserSession } from "@/lib/auth";
+import { generateS3Urls } from "@/actions/soundfileUrl";
 
 type Params = {
     searchParams: Promise<{
@@ -25,6 +26,20 @@ export default async function AdminView({ searchParams }: Params) {
     });
     const totalPages = Math.ceil(res.totalResults / 10);
 
+    // Generera URL:er bara för de ljudfiler som visas på den här sidan.
+    const filenames = res.rawData
+            .map((item) => item.fileName)
+            .filter((fileName): fileName is string => Boolean(fileName));
+        const soundFileUrls = await generateS3Urls(filenames);
+    
+        // loopa igenom res.data och lägg till soundFileUrl för varje objekt som har en fileName
+        const tableDataWithUrls = res.rawData
+            // .filter((item) => item.fileName) // Filtrera bara de objekt som har en fileName
+            .map((item) => ({
+                ...item,
+                soundFileUrl: soundFileUrls[item.fileName as string] || null, // Lägg till soundFileUrl baserat på fileName
+            }));
+
     return (
         <main>
             <div className={styles.tableContainerWrapper}>
@@ -43,7 +58,7 @@ export default async function AdminView({ searchParams }: Params) {
                                 </Link>
                             </div>
                         </div>
-                        <AdminTable tableData={res.rawData} />
+                        <AdminTable tableData={tableDataWithUrls} />
                     </div>
                     <ImportExcelSection />
                 </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,15 +28,15 @@ export default async function Home({ searchParams }: params) {
     // Generera URL:er bara för de ljudfiler som visas på den här sidan.
     const filenames = res.rawData
         .map((item) => item.fileName)
-        .filter((fileName): fileName is string => Boolean(fileName));
+        .filter(fileName => Boolean(fileName))
+        .filter(fileName => fileName !== null);
     const soundFileUrls = await generateS3Urls(filenames);
 
     // loopa igenom res.data och lägg till soundFileUrl för varje objekt som har en fileName
     const tableDataWithUrls = res.rawData
-        // .filter((item) => item.fileName) // Filtrera bara de objekt som har en fileName
         .map((item) => ({
             ...item,
-            soundFileUrl: soundFileUrls[item.fileName as string] || null, // Lägg till soundFileUrl baserat på fileName
+            soundFileUrl: item.fileName ? soundFileUrls[item.fileName] : null // Lägg till soundFileUrl baserat på fileName
         }));
 
     return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import SearchField from "@/components/Searchfield";
 import Link from "next/link";
 import { GetAllDialectwords } from "@/actions/dialectwords";
 import { getInactiveUserSession } from "@/lib/auth";
+import { generateS3Urls } from "@/actions/soundfileUrl";
 
 type params = {
     searchParams: Promise<{
@@ -23,6 +24,20 @@ export default async function Home({ searchParams }: params) {
     const totalPages = Math.ceil(res.totalResults / 10); // 10 is the pageSize;
 
     const userSession = await getInactiveUserSession();
+
+    // Generera URL:er bara för de ljudfiler som visas på den här sidan.
+    const filenames = res.rawData
+        .map((item) => item.fileName)
+        .filter((fileName): fileName is string => Boolean(fileName));
+    const soundFileUrls = await generateS3Urls(filenames);
+
+    // loopa igenom res.data och lägg till soundFileUrl för varje objekt som har en fileName
+    const tableDataWithUrls = res.rawData
+        // .filter((item) => item.fileName) // Filtrera bara de objekt som har en fileName
+        .map((item) => ({
+            ...item,
+            soundFileUrl: soundFileUrls[item.fileName as string] || null, // Lägg till soundFileUrl baserat på fileName
+        }));
 
     return (
         <main>
@@ -47,7 +62,7 @@ export default async function Home({ searchParams }: params) {
                                 </div>
                             )}
                         </div>
-                        <Table tableData={res.rawData} />
+                        <Table tableData={tableDataWithUrls} />
                     </div>
                     <Pagination page={+page} totalPages={totalPages} />
                 </div>

--- a/src/components/Admin/AdminTable.tsx
+++ b/src/components/Admin/AdminTable.tsx
@@ -143,7 +143,7 @@ export default function AdminTable({ tableData }: AdminTableProps) {
                                         type="button"
                                         aria-label="Spela upp ljud"
                                         onClick={() =>
-                                            playSound(item.fileName || ":)")
+                                            playSound(item.soundFileUrl || ":)")
                                         }>
                                         ▶️
                                     </button>

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -2,8 +2,12 @@
 import styles from "../app/page.module.css";
 import { DialectWordTableResponse } from "@/types/DialektFormValidation/dialectWord";
 
+type TableRow = DialectWordTableResponse & {
+    soundFileUrl: string | null;
+};
+
 type TableProps = {
-    tableData: DialectWordTableResponse[] | null; // Object containing pagination info and an array of objects with word, pronunciation, sound file URL, etc.
+    tableData: TableRow[] | null; // Object containing pagination info and an array of objects with word, pronunciation, sound file URL, etc.
 };
 
 // The Table-component recives "tableData" as a prop from the parent component (e.g. the page).
@@ -35,7 +39,7 @@ export default function Table({ tableData }: TableProps) {
                             <td className={styles.tableCell}>{item.word}</td>
                             <td className={styles.tableCell}>
                                 {/* Show play button if a sound file exists */}
-                                {item.fileName && (
+                                {item.soundFileUrl && (
                                     <button
                                         style={{
                                             border: "none",
@@ -44,10 +48,12 @@ export default function Table({ tableData }: TableProps) {
                                         }}
                                         type="button"
                                         aria-label="Spela upp ljud"
-                                        onClick={() =>
-                                            playSound(item.fileName || ":)")
-                                        }>
-                                        ▶️{" "}
+                                        onClick={() => {
+                                            if (item.soundFileUrl) {
+                                                playSound(item.soundFileUrl);
+                                            }
+                                        }}>
+                                        ▶️
                                     </button>
                                 )}
                             </td>

--- a/src/types/DialektFormValidation/dialectWord.ts
+++ b/src/types/DialektFormValidation/dialectWord.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Status } from "../status";
 import { AllowedFileTypes, MaxFileSize } from "./audioFileConstraints";
+import { soundFileTable } from "@/Drizzle/models/SoundFile";
 // TypeScript interface for the API response
 
 export const DialectWordTableResponse = z.object({
@@ -10,6 +11,7 @@ export const DialectWordTableResponse = z.object({
     userName: z.string().nullable(),
     nationalWord: z.string().nullable(),
     fileName: z.string().nullable(),
+    soundFileUrl: z.string().nullable().optional(),
 });
 export type DialectWordTableResponse = z.infer<typeof DialectWordTableResponse>;
 


### PR DESCRIPTION
This pull request introduces support for generating and displaying presigned S3 URLs for sound files associated with dialect words. The main change is that both the admin and public tables now show a play button that streams audio directly from S3 using a secure, time-limited URL, rather than relying on just the file name. The update also ensures that only sound files visible on the current page have URLs generated, improving efficiency.

**Backend S3 URL generation:**

* Added a new server action `generateS3Urls` in `src/actions/soundfileUrl.ts` to generate presigned S3 URLs for a list of filenames, using AWS SDK and returning a mapping from filename to URL.

**Integration into page data flows:**

* Updated both `src/app/adminView/page.tsx` and `src/app/page.tsx` to:
  * Import and use `generateS3Urls` to generate URLs only for the sound files shown on the current page.
  * Enhance each table row’s data with a `soundFileUrl` property, mapped from the generated URLs. [[1]](diffhunk://#diff-38812e06eb7e505ffd9435a5e62f7c2bc78fb73c8820ca4b00dca19bf468179dR9) [[2]](diffhunk://#diff-38812e06eb7e505ffd9435a5e62f7c2bc78fb73c8820ca4b00dca19bf468179dR29-R42) [[3]](diffhunk://#diff-38812e06eb7e505ffd9435a5e62f7c2bc78fb73c8820ca4b00dca19bf468179dL46-R61) [[4]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR8) [[5]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR28-R41) [[6]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL50-R65)

**Table and play button updates:**

* Modified `AdminTable` and `Table` components to:
  * Use `soundFileUrl` instead of `fileName` for the play button.
  * Only show/play the button if a valid `soundFileUrl` is present, ensuring playback streams directly from S3. [[1]](diffhunk://#diff-0b23ec2302a8c9bb1a3a1a1f895b54f45c91cca13ec29cea0060ddad7c1d5951L146-R146) [[2]](diffhunk://#diff-8cb97d363debc9c1adf3032b1ceb55c11cc1afec35ce34981f8f63fa3df2abc8R5-R10) [[3]](diffhunk://#diff-8cb97d363debc9c1adf3032b1ceb55c11cc1afec35ce34981f8f63fa3df2abc8L38-R42) [[4]](diffhunk://#diff-8cb97d363debc9c1adf3032b1ceb55c11cc1afec35ce34981f8f63fa3df2abc8L47-R56)

**Type and schema changes:**

* Extended the `DialectWordTableResponse` type and schema to include an optional `soundFileUrl` property, ensuring type safety throughout the data flow. [[1]](diffhunk://#diff-a65e898cb90a57cb0207d81e5e1204ef781527a7125a584125c7e610b4ec9125R4) [[2]](diffhunk://#diff-a65e898cb90a57cb0207d81e5e1204ef781527a7125a584125c7e610b4ec9125R14)