### PR TITLE
50 status hantering

### DIFF
--- a/src/Drizzle/index.ts
+++ b/src/Drizzle/index.ts
@@ -19,10 +19,9 @@ export const connection = mysql.createPool({
     user: env.MYSQL_USER,
     password: env.MYSQL_PASSWORD,
     database: env.MYSQL_DATABASE,
-    pool: {
-        min: 2,
-        max: 10,
-    },
+    waitForConnections: true,
+    connectionLimit: 10,
+    queueLimit: 0,
 });
 const db = drizzle(connection, { schema, mode: "default" });
 

--- a/src/actions/dialectwords.ts
+++ b/src/actions/dialectwords.ts
@@ -195,14 +195,8 @@ export async function UpdateDialectWord(data: updateDialectWord) {
         throw new Error("User must be logged in to update a dialect word.");
     }
 
-    // Todo: Move this schema to a separate file since it cam be used in multiple places
-    const updateWordSchema = z.object({
-        id: z.number(),
-        dialectWord: z.string(),
-        nationalWord: z.string(),
-    });
 
-    const parsedData = updateWordSchema.safeParse(data);
+    const parsedData = updateDialectWord.safeParse(data);
 
     if (!parsedData.success) {
         throw new Error(

--- a/src/actions/dialectwords.ts
+++ b/src/actions/dialectwords.ts
@@ -6,7 +6,7 @@ import { dialectWordTable } from "@/Drizzle/models/DialectWord";
 import { nationalWordTable } from "@/Drizzle/models/NationalWord";
 import { soundFileTable } from "@/Drizzle/models/SoundFile";
 import { env } from "@/env";
-import { auth } from "@/lib/auth";
+import { auth, getAdminSession } from "@/lib/auth";
 import { s3Client } from "@/lib/s3Client";
 import {
     addDialectWord,
@@ -15,10 +15,14 @@ import {
 import { dialectWordApi } from "@/types/DialektFormValidation/dialectWordApiSchema";
 import { Status } from "@/types/status";
 import { GetNumberFromStatus } from "@/utils/enumConverter";
-import { PutObjectCommand, PutObjectCommandInput } from "@aws-sdk/client-s3";
+import {
+    DeleteObjectCommand,
+    DeleteObjectCommandInput,
+    PutObjectCommand,
+    PutObjectCommandInput,
+} from "@aws-sdk/client-s3";
 import { count, eq, sql, like, or, and } from "drizzle-orm";
 import { headers } from "next/headers";
-import z from "zod";
 
 type GetParams = {
     query: string;
@@ -197,7 +201,6 @@ export async function UpdateDialectWord(data: updateDialectWord) {
         throw new Error("User must be logged in to update a dialect word.");
     }
 
-
     const parsedData = updateDialectWord.safeParse(data);
 
     if (!parsedData.success) {
@@ -247,6 +250,75 @@ export async function UpdateDialectWord(data: updateDialectWord) {
             nationalWord: updateWord.nationalWord,
         },
     };
+}
+
+export async function UpdateDialectWordStatus(
+    dialectWordId: number,
+    newStatus: Status,
+) {
+    const currentUser = await getAdminSession();
+
+    if (!currentUser) {
+        throw new Error("User must be logged in to update a dialect word.");
+    }
+
+    try {
+        if (
+            newStatus === Status.enum.approved ||
+            newStatus === Status.enum.pending
+        ) {
+            await db
+                .update(dialectWordTable)
+                .set({ status: GetNumberFromStatus(newStatus) })
+                .where(eq(dialectWordTable.id, dialectWordId));
+        }
+        if (newStatus === Status.enum.rejected) {
+            const wordToDelete = (
+                await db
+                    .select({
+                        soundFileName: soundFileTable.fileName,
+                    })
+                    .from(dialectWordTable)
+                    .leftJoin(
+                        soundFileTable,
+                        eq(dialectWordTable.soundFileId, soundFileTable.id),
+                    )
+                    .where(eq(dialectWordTable.id, dialectWordId))
+                    .limit(1)
+            ).at(0);
+
+            // Om det finns en ljudfil kopplad till ordet, ta bort den från S3
+            if (wordToDelete && wordToDelete.soundFileName) {
+                const deleteCommandInput = {
+                    Bucket: env.S3_BUCKET_NAME,
+                    Key: wordToDelete.soundFileName,
+                } satisfies DeleteObjectCommandInput;
+                const deleteCommand = new DeleteObjectCommand(
+                    deleteCommandInput,
+                );
+                await s3Client.send(deleteCommand);
+
+                await db
+                    .delete(dialectWordTable)
+                    .where(eq(dialectWordTable.id, dialectWordId));
+
+                await db
+                    .delete(soundFileTable)
+                    .where(
+                        eq(soundFileTable.fileName, wordToDelete.soundFileName),
+                    );
+                return;
+            }
+
+            await db
+                .delete(dialectWordTable)
+                .where(eq(dialectWordTable.id, dialectWordId));
+        }
+    } catch {
+        throw new Error(
+            "Ett fel uppstod vid uppdatering av dialektordets status.",
+        );
+    }
 }
 
 export async function SearchDialectWords({ page, pageSize, query }: GetParams) {

--- a/src/actions/dialectwords.ts
+++ b/src/actions/dialectwords.ts
@@ -154,7 +154,6 @@ export async function CreateDialectWord(data: addDialectWord) {
             nationalWordId = insertedNationalWord[0].id;
         }
 
-        
         let soundFileId: { id: number } | undefined = undefined;
         if (audioFile && audioFileName) {
             const arraybuffer = await audioFile.arrayBuffer();
@@ -163,7 +162,6 @@ export async function CreateDialectWord(data: addDialectWord) {
                 Key: audioFileName,
                 Body: new Uint8Array(arraybuffer),
                 ContentType: audioFile.type,
-                
             } satisfies PutObjectCommandInput;
 
             const command = new PutObjectCommand(uploadParams);
@@ -188,7 +186,7 @@ export async function CreateDialectWord(data: addDialectWord) {
     });
 }
 
-export async function UpdateDialectword(data: updateDialectWord) {
+export async function UpdateDialectWord(data: updateDialectWord) {
     const currentUser = await auth.api.getSession({
         headers: await headers(),
     });

--- a/src/actions/importExcelToDb.ts
+++ b/src/actions/importExcelToDb.ts
@@ -6,7 +6,6 @@ import { headers } from "next/headers";
 import { eq, and } from "drizzle-orm";
 import { dialectWordTable } from "@/Drizzle/models/DialectWord";
 import { nationalWordTable } from "@/Drizzle/models/NationalWord";
-import { soundFileTable } from "@/Drizzle/models/SoundFile";
 
 // Typ för en rad från Excel-filen
 export type ExcelWordRow = {
@@ -31,24 +30,6 @@ async function getOrCreateNationalWord(word: string) {
     return createdNationalWord[0].id;
 }
 
-// Hämta eller skapa soundfile för ett ord
-async function getOrCreateSoundFile(file_name: string) {
-    const existing = await db
-        .select({ id: soundFileTable.id })
-        .from(soundFileTable)
-        .where(eq(soundFileTable.fileName, file_name));
-    if (existing.length > 0) return existing[0].id;
-
-    await db.insert(soundFileTable).values({
-        fileName: file_name,
-    });
-
-    const createdSoundFile = await db
-        .select({ id: soundFileTable.id })
-        .from(soundFileTable)
-        .where(eq(soundFileTable.fileName, file_name));
-    return createdSoundFile[0].id;
-}
 
 async function CheckMachingRows(dialectWord: string, nationalWord: string) {
     // Hämta id för det nationella ordet (nationalWord) från nationalWordTable
@@ -90,14 +71,11 @@ export async function importExcelRows(rows: ExcelWordRow[]) {
 
     for (const row of rows) {
         const nationalWordId = await getOrCreateNationalWord(row.nationalWord);
-        const soundFileId = await getOrCreateSoundFile(
-            `${row.dialectWord}.mp3`,
-        );
 
         // Om något är fel med nationalWordId eller soundFileId,
         // logga felet, lägg inte till raden och fortsätt till nästa rad.
         // om dialektordet redan finns, logga en varning, lägg inte till raden och fortsätt till nästa rad.
-        if (!nationalWordId || !soundFileId) {
+        if (!nationalWordId) {
             console.error(
                 `Failed to get or create national word or sound file for row: ${JSON.stringify(row)}
                 )}`,
@@ -114,7 +92,6 @@ export async function importExcelRows(rows: ExcelWordRow[]) {
         await db.insert(dialectWordTable).values({
             word: row.dialectWord,
             nationalWordId,
-            soundFileId,
             userId: currentUser.user.id,
             status: 1,
         });

--- a/src/components/Admin/AdminTable.tsx
+++ b/src/components/Admin/AdminTable.tsx
@@ -132,13 +132,13 @@ export default function AdminTable({ tableData }: AdminTableProps) {
                                         )
                                     }>
                                     <option value={Status.enum.approved}>
-                                        Publicerad
+                                        Publicera
                                     </option>
                                     <option value={Status.enum.pending}>
                                         Ej publicerad
                                     </option>
                                     <option value={Status.enum.rejected}>
-                                        Avslagen
+                                        Neka
                                     </option>
                                 </select>
                             </td>

--- a/src/components/Admin/AdminTable.tsx
+++ b/src/components/Admin/AdminTable.tsx
@@ -5,13 +5,16 @@ import pageStyles from "@/app/page.module.css";
 import styles from "./AdminTable.module.css";
 import { DialectWordTableResponse } from "@/types/DialektFormValidation/dialectWord";
 import EditWordForm, { EditWordFormUpdatedData } from "./EditWordForm";
+import { Status } from "@/types/status";
 
 type AdminTableProps = {
     tableData: DialectWordTableResponse[] | null;
 };
 
 export default function AdminTable({ tableData }: AdminTableProps) {
-    const [rows, setRows] = useState<DialectWordTableResponse[]>( tableData ?? [], );
+    const [rows, setRows] = useState<DialectWordTableResponse[]>(
+        tableData ?? [],
+    );
     const [editingId, setEditingId] = useState<number | null>(null);
     const [savedRowId, setSavedRowId] = useState<number | null>(null);
 
@@ -64,26 +67,35 @@ export default function AdminTable({ tableData }: AdminTableProps) {
         setSavedRowId(updated.id);
     };
 
+    const handleStatusChange = (id: number, isPublished: Status) => {
+        console.log({ id, isPublished });
+
+        setRows((prevRows) =>
+            prevRows.map((row) =>
+                row.id === id ? { ...row, status: isPublished } : row,
+            ),
+        );
+    };
+
     return (
         <table className={`${pageStyles.table} ${styles.adminTable}`}>
             <thead>
                 <tr>
-                    <th className={pageStyles.tableHeaderCell}>{"Dialekt"}</th>
-                    <th className={pageStyles.tableHeaderCell}>{"Ljudfil"}</th>
-                    <th className={pageStyles.tableHeaderCell}>{"Svenska"}</th>
-                    <th className={pageStyles.tableHeaderCell}>
-                        {"Användare"}
-                    </th>
-                    <th className={pageStyles.tableHeaderCell}>
-                        {"Hantering"}
-                    </th>
+                    <th className={pageStyles.tableHeaderCell}>Dialekt</th>
+                    <th className={pageStyles.tableHeaderCell}>Ljudfil</th>
+                    <th className={pageStyles.tableHeaderCell}>Svenska</th>
+                    <th className={pageStyles.tableHeaderCell}>Användare</th>
+                    <th className={pageStyles.tableHeaderCell}>Publicerad</th>
+                    <th className={pageStyles.tableHeaderCell}>Hantering</th>
                 </tr>
             </thead>
             <tbody>
                 {rows.map((item) => (
                     <>
                         <tr key={item.id}>
-                            <td className={pageStyles.tableCell}>{item.word}</td>
+                            <td className={pageStyles.tableCell}>
+                                {item.word}
+                            </td>
                             <td className={pageStyles.tableCell}>
                                 {item.fileName && item.soundFileUrl && (
                                     <button
@@ -94,13 +106,36 @@ export default function AdminTable({ tableData }: AdminTableProps) {
                                         }}
                                         type="button"
                                         aria-label="Spela upp ljud"
-                                        onClick={() => playSound(item.soundFileUrl!)}>
+                                        onClick={() =>
+                                            playSound(item.soundFileUrl!)
+                                        }>
                                         ▶️
                                     </button>
                                 )}
                             </td>
-                            <td className={pageStyles.tableCell}>{item.nationalWord}</td>
-                            <td className={pageStyles.tableCell}>{item.userName}</td>
+                            <td className={pageStyles.tableCell}>
+                                {item.nationalWord}
+                            </td>
+                            <td className={pageStyles.tableCell}>
+                                {item.userName}
+                            </td>
+                            <td className={pageStyles.tableCell}>
+                                <select
+                                    value={item.status}
+                                    onChange={(changeEvent) =>
+                                        handleStatusChange(
+                                            item.id,
+                                            changeEvent.target.value as Status,
+                                        )
+                                    }>
+                                    <option value={Status.enum.approved}>
+                                        Publicerad
+                                    </option>
+                                    <option value={Status.enum.rejected}>
+                                        Ej publicerad
+                                    </option>
+                                </select>
+                            </td>
                             <td
                                 className={`${pageStyles.tableCell} ${styles.adminActionCell}`}>
                                 <div className={styles.actionWrapper}>
@@ -111,7 +146,9 @@ export default function AdminTable({ tableData }: AdminTableProps) {
                                         Edit
                                     </button>
                                     {savedRowId === item.id && (
-                                        <span className={styles.savedText}>Sparat</span>
+                                        <span className={styles.savedText}>
+                                            Sparat
+                                        </span>
                                     )}
                                 </div>
                             </td>
@@ -119,7 +156,7 @@ export default function AdminTable({ tableData }: AdminTableProps) {
 
                         {editingId === item.id && (
                             <tr>
-                                <td className={styles.editRowCell} colSpan={5}>
+                                <td className={styles.editRowCell} colSpan={6}>
                                     <EditWordForm
                                         id={item.id}
                                         dialectWord={item.word}

--- a/src/components/Admin/AdminTable.tsx
+++ b/src/components/Admin/AdminTable.tsx
@@ -6,6 +6,7 @@ import styles from "./AdminTable.module.css";
 import { DialectWordTableResponse } from "@/types/DialektFormValidation/dialectWord";
 import EditWordForm, { EditWordFormUpdatedData } from "./EditWordForm";
 import { Status } from "@/types/status";
+import { UpdateDialectWordStatus } from "@/actions/dialectwords";
 
 type AdminTableProps = {
     tableData: DialectWordTableResponse[] | null;
@@ -67,7 +68,7 @@ export default function AdminTable({ tableData }: AdminTableProps) {
         setSavedRowId(updated.id);
     };
 
-    const handleStatusChange = (id: number, isPublished: Status) => {
+    const handleStatusChange = async (id: number, isPublished: Status) => {
         console.log({ id, isPublished });
 
         setRows((prevRows) =>
@@ -75,6 +76,7 @@ export default function AdminTable({ tableData }: AdminTableProps) {
                 row.id === id ? { ...row, status: isPublished } : row,
             ),
         );
+        await UpdateDialectWordStatus(id, isPublished);
     };
 
     return (
@@ -131,8 +133,11 @@ export default function AdminTable({ tableData }: AdminTableProps) {
                                     <option value={Status.enum.approved}>
                                         Publicerad
                                     </option>
-                                    <option value={Status.enum.rejected}>
+                                    <option value={Status.enum.pending}>
                                         Ej publicerad
+                                    </option>
+                                    <option value={Status.enum.rejected}>
+                                        Avslagen
                                     </option>
                                 </select>
                             </td>

--- a/src/components/Admin/AdminTable.tsx
+++ b/src/components/Admin/AdminTable.tsx
@@ -7,6 +7,7 @@ import { DialectWordTableResponse } from "@/types/DialektFormValidation/dialectW
 import EditWordForm, { EditWordFormUpdatedData } from "./EditWordForm";
 import { Status } from "@/types/status";
 import { UpdateDialectWordStatus } from "@/actions/dialectwords";
+import PlayIcon from "../PlayIcon";
 
 type AdminTableProps = {
     tableData: DialectWordTableResponse[] | null;
@@ -111,7 +112,7 @@ export default function AdminTable({ tableData }: AdminTableProps) {
                                         onClick={() =>
                                             playSound(item.soundFileUrl!)
                                         }>
-                                        ▶️
+                                        <PlayIcon />
                                     </button>
                                 )}
                             </td>

--- a/src/components/Admin/EditWordForm.tsx
+++ b/src/components/Admin/EditWordForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
-import { UpdateDialectword } from "@/actions/dialectwords";
+import { UpdateDialectWord } from "@/actions/dialectwords";
 import styles from "./AdminTable.module.css";
 import { editWordForm } from "@/types/editWordFormValidation";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -33,7 +33,7 @@ export default function EditWordForm({
         handleSubmit,
         reset,
         formState: { errors },
-        setError // Missing setError from useForm
+        setError, // Missing setError from useForm
     } = useForm<editWordForm>({
         resolver: zodResolver(editWordForm), // missing resolver for validation
         defaultValues: {
@@ -57,7 +57,7 @@ export default function EditWordForm({
         // setError("");
 
         try {
-            await UpdateDialectword({
+            await UpdateDialectWord({
                 id,
                 dialectWord: values.dialectWord,
                 nationalWord: values.nationalWord,
@@ -127,7 +127,9 @@ export default function EditWordForm({
                 <p className={styles.errorText}>{errors.dialectWord.message}</p>
             )}
             {errors.nationalWord && (
-                <p className={styles.errorText}>{errors.nationalWord.message}</p>
+                <p className={styles.errorText}>
+                    {errors.nationalWord.message}
+                </p>
             )}
         </form>
     );

--- a/src/components/PlayIcon.tsx
+++ b/src/components/PlayIcon.tsx
@@ -1,0 +1,12 @@
+function PlayIcon() {
+    // !Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.
+    return (
+        <svg 
+        style={{ width: "20px", height: "20px", fill: "var(--color-blue)" }}
+        xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640">
+            <path d="M187.2 100.9C174.8 94.1 159.8 94.4 147.6 101.6C135.4 108.8 128 121.9 128 136L128 504C128 518.1 135.5 531.2 147.6 538.4C159.7 545.6 174.8 545.9 187.2 539.1L523.2 355.1C536 348.1 544 334.6 544 320C544 305.4 536 291.9 523.2 284.9L187.2 100.9z" />
+        </svg>
+    );
+}
+
+export default PlayIcon;

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,6 +1,7 @@
 "use client";
 import styles from "../app/page.module.css";
 import { DialectWordTableResponse } from "@/types/DialektFormValidation/dialectWord";
+import PlayIcon from "./PlayIcon";
 
 type TableRow = DialectWordTableResponse & {
     soundFileUrl: string | null;
@@ -53,7 +54,7 @@ export default function Table({ tableData }: TableProps) {
                                                 playSound(item.soundFileUrl);
                                             }
                                         }}>
-                                        ▶️
+                                        <PlayIcon />
                                     </button>
                                 )}
                             </td>

--- a/src/types/DialektFormValidation/dialectWord.ts
+++ b/src/types/DialektFormValidation/dialectWord.ts
@@ -41,6 +41,7 @@ export type addDialectWord = z.infer<typeof addDialectWord>;
 
 export const updateDialectWord = z.object({
     id: z.number(),
+    status: Status.default("pending").optional(),
     dialectWord: z.string().min(1, "Dialekt ord är obligatoriskt"),
     nationalWord: z.string().min(1, "Nationellt ord är obligatoriskt"),
 });


### PR DESCRIPTION
This pull request introduces several improvements to the dialect word admin functionality, focusing on status management, user interface enhancements, and code consistency. The main changes include adding a dedicated status update function for dialect words (with appropriate handling for deleting associated sound files), updating the admin table to allow status changes directly from the UI, and replacing the play button with a consistent icon component.

**Admin functionality and status management:**

* Added a new `UpdateDialectWordStatus` function in `src/actions/dialectwords.ts` that allows admins to update the status of a dialect word (approved, pending, or rejected). If a word is rejected and has an associated sound file, the sound file is deleted from S3 and the relevant database entries are removed.
* Updated the admin table (`src/components/Admin/AdminTable.tsx`) to include a status dropdown for each word, enabling admins to change word status directly from the UI. The dropdown is wired to the new status update function. [[1]](diffhunk://#diff-0b23ec2302a8c9bb1a3a1a1f895b54f45c91cca13ec29cea0060ddad7c1d5951R72-R101) [[2]](diffhunk://#diff-0b23ec2302a8c9bb1a3a1a1f895b54f45c91cca13ec29cea0060ddad7c1d5951L97-R144) [[3]](diffhunk://#diff-0b23ec2302a8c9bb1a3a1a1f895b54f45c91cca13ec29cea0060ddad7c1d5951L114-R165)

**UI and code consistency improvements:**

* Replaced the text play button with a new `PlayIcon` SVG component for consistent appearance in both the main and admin tables. [[1]](diffhunk://#diff-6a61027ade92b22d9994e4ce596c696dc72881123dfb5567165f17303dc94615R1-R12) [[2]](diffhunk://#diff-0b23ec2302a8c9bb1a3a1a1f895b54f45c91cca13ec29cea0060ddad7c1d5951R8-R19) [[3]](diffhunk://#diff-8cb97d363debc9c1adf3032b1ceb55c11cc1afec35ce34981f8f63fa3df2abc8R4) [[4]](diffhunk://#diff-8cb97d363debc9c1adf3032b1ceb55c11cc1afec35ce34981f8f63fa3df2abc8L56-R57) [[5]](diffhunk://#diff-0b23ec2302a8c9bb1a3a1a1f895b54f45c91cca13ec29cea0060ddad7c1d5951L97-R144)
* Standardized the spelling of `UpdateDialectWord` (previously `UpdateDialectword`) in imports and function names for consistency. [[1]](diffhunk://#diff-1f3c48fd609fe1a546af405af2c888f60897dcd2407691a3d781875326409d65L187-R192) [[2]](diffhunk://#diff-8da024c0cfc68e65a2eb07b1eb363e5708278bac87ad9f4f01750bc321845639L3-R3) [[3]](diffhunk://#diff-8da024c0cfc68e65a2eb07b1eb363e5708278bac87ad9f4f01750bc321845639L56-R56)

**Other improvements:**

* Updated the MySQL connection pool configuration in `src/Drizzle/index.ts` for better connection handling.
* Added a default value for the `status` field in the `updateDialectWord` schema to ensure status is always set.
* Enhanced S3 client imports to support delete operations for sound files.
* Added the `getAdminSession` import to support admin-only actions.