### PR TITLE
76 move admin components to a nav menu

### DIFF
--- a/src/app/adminView/importExcel/page.module.css
+++ b/src/app/adminView/importExcel/page.module.css
@@ -1,0 +1,6 @@
+.importExcelContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 20px 0px;
+}

--- a/src/app/adminView/importExcel/page.tsx
+++ b/src/app/adminView/importExcel/page.tsx
@@ -1,0 +1,14 @@
+import ImportExcelSection from "@/components/Admin/ImportExcelSection";
+import styles from "./page.module.css";
+
+const ImportExcelPage = () => {
+    return (
+        <div className={styles.importExcelContainer}>
+            <h1>Importera Excel</h1>
+            <p>Här kan du importera ord från en Excel-fil.</p>
+            <ImportExcelSection />
+        </div>
+    );
+};
+
+export default ImportExcelPage;

--- a/src/app/adminView/layout.module.css
+++ b/src/app/adminView/layout.module.css
@@ -1,0 +1,40 @@
+
+.layoutContainer {
+    display: flex;
+}
+.sidebar {
+    width: 200px;
+    padding: 20px;
+    background-color: #f9f9f9;
+    border-right: solid 1px #e0e0e0;
+}
+
+.navContainer {
+    display: flex;
+    margin-bottom: auto;
+    border-bottom: solid 1px #e0e0e0;
+    width: 100%;
+    .navItem {
+        padding: 10px 10px;
+        font-weight: bold;
+        color: var(--color-blue);
+        list-style: none;
+        &.active {
+            color: white;
+            background-color: var(--color-blue);
+        }
+    } 
+    .navItem:not(.active):hover {
+        scale: 1.05;
+    }
+}
+
+
+
+.contentContainer {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}

--- a/src/app/adminView/layout.tsx
+++ b/src/app/adminView/layout.tsx
@@ -1,0 +1,15 @@
+
+import styles from "./layout.module.css";
+import { AdminSidebar } from "@/components/Admin/AdminSidbar";
+
+export default function AdminLayout({ children } : { children: React.ReactNode }) 
+{
+    return (
+        <div className={styles.layoutContainer}>
+            <AdminSidebar />
+            <div className={styles.contentContainer}>
+                    {children}
+            </div>
+        </div>
+    );
+}

--- a/src/app/adminView/page.tsx
+++ b/src/app/adminView/page.tsx
@@ -1,9 +1,7 @@
 import styles from "../page.module.css";
 import Pagination from "../../components/Pagination";
 import AdminTable from "@/components/Admin/AdminTable";
-import AdminUserRoles from "@/components/Admin/AdminUserRoles";
 import SearchField from "@/components/Searchfield";
-import ImportExcelSection from "@/components/Admin/ImportExcelSection";
 import Link from "next/link";
 import { GetAllDialectwords } from "@/actions/dialectwords";
 import { getAdminSession } from "@/lib/auth";

--- a/src/app/adminView/page.tsx
+++ b/src/app/adminView/page.tsx
@@ -62,10 +62,6 @@ export default async function AdminView({ searchParams }: Params) {
                         <AdminTable tableData={tableDataWithUrls} />
                     </div>
                     <Pagination page={+page} totalPages={totalPages} />
-                    <div className={styles.extraAdminSection}>
-                    <ImportExcelSection />
-                    <AdminUserRoles />
-                    </div>
                 </div>
             </div>
         </main>

--- a/src/app/adminView/userRoles/page.module.css
+++ b/src/app/adminView/userRoles/page.module.css
@@ -1,0 +1,8 @@
+.userRolesContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 20px 0px;
+    margin: 0 auto;
+    width: 100%;
+}

--- a/src/app/adminView/userRoles/page.tsx
+++ b/src/app/adminView/userRoles/page.tsx
@@ -1,0 +1,14 @@
+import AdminUserRoles from "@/components/Admin/AdminUserRoles";
+import styles from "./page.module.css";
+
+const userRoles = () => {
+    return (
+        <div className={styles.userRolesContainer}>
+            <h1>Användarroller</h1>
+            <p>Här kan du ändra användarroller.</p>
+            <AdminUserRoles />
+        </div>
+    );
+};
+
+export default userRoles;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,6 +45,7 @@ export default async function Home({ searchParams }: params) {
                 <div>
                     <div className={styles.tableContainer}>
                         <SearchField />
+                        <Pagination page={+page} totalPages={totalPages} />
                         <div className={styles.tableHeader}>
                             <h2>Ordlista</h2>
                             {userSession && (

--- a/src/components/Admin/AdminSidbar.tsx
+++ b/src/components/Admin/AdminSidbar.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import styles from "../../app/adminView/layout.module.css";
+
+export function AdminSidebar() {
+
+    const pathname = usePathname();
+
+    return (
+        <aside className={styles.sidebar}>
+                <nav className={styles.navContainer} >
+                    <ul>
+                        <li className={`${styles.navItem} ${pathname === "/adminView" ? styles.active : ""}`}><a href="/adminView">Dashboard</a></li>
+                        <li className={`${styles.navItem} ${pathname === "/adminView/importExcel" ? styles.active : ""}`}><a href="/adminView/importExcel">Import Excel</a></li>
+                        <li className={`${styles.navItem} ${pathname === "/adminView/userRoles" ? styles.active : ""}`}><a href="/adminView/userRoles">Change User Roles</a></li>
+                    </ul>
+                </nav>
+            </aside>
+    )
+}

--- a/src/components/Admin/AdminSidbar.tsx
+++ b/src/components/Admin/AdminSidbar.tsx
@@ -11,9 +11,9 @@ export function AdminSidebar() {
         <aside className={styles.sidebar}>
                 <nav className={styles.navContainer} >
                     <ul>
-                        <li className={`${styles.navItem} ${pathname === "/adminView" ? styles.active : ""}`}><a href="/adminView">Dashboard</a></li>
-                        <li className={`${styles.navItem} ${pathname === "/adminView/importExcel" ? styles.active : ""}`}><a href="/adminView/importExcel">Import Excel</a></li>
-                        <li className={`${styles.navItem} ${pathname === "/adminView/userRoles" ? styles.active : ""}`}><a href="/adminView/userRoles">Change User Roles</a></li>
+                        <li className={`${styles.navItem} ${pathname === "/adminView" ? styles.active : ""}`}><a href="/adminView">AdminVy</a></li>
+                        <li className={`${styles.navItem} ${pathname === "/adminView/importExcel" ? styles.active : ""}`}><a href="/adminView/importExcel">Importera Excelfil</a></li>
+                        <li className={`${styles.navItem} ${pathname === "/adminView/userRoles" ? styles.active : ""}`}><a href="/adminView/userRoles">Ändra användarroller</a></li>
                     </ul>
                 </nav>
             </aside>


### PR DESCRIPTION
This pull request refactors the admin view by introducing a new layout with a sidebar for navigation and reorganizing the admin-related pages into separate routes. It also adds dedicated styling for each admin subpage and improves the user experience by providing clear navigation and structure.

**Admin Layout and Navigation Improvements:**

* Added a new `AdminLayout` component with a sidebar navigation (`AdminSidebar`) for the admin section, and applied corresponding layout styles in `layout.module.css`. This provides a consistent structure and easy navigation between admin subpages. [[1]](diffhunk://#diff-930710d51195f7c81e631e7f48745d1862a749b9e730d64bb3f9489c0c732c12R1-R15) [[2]](diffhunk://#diff-d3c0beae97871de7df45ef870f79fabecc1c840424759db7ab6c9e2b8a56d434R1-R21) [[3]](diffhunk://#diff-5687cbfd3acd0c595c4d7966d017ad4ce8ea090c5efb319939175848f0d544f5R1-R40)
* Removed inline admin sections (Excel import and user roles) from the main admin page, moving them to dedicated routes and pages for better separation of concerns. [[1]](diffhunk://#diff-38812e06eb7e505ffd9435a5e62f7c2bc78fb73c8820ca4b00dca19bf468179dL4-L6) [[2]](diffhunk://#diff-38812e06eb7e505ffd9435a5e62f7c2bc78fb73c8820ca4b00dca19bf468179dL65-L68)

**New Admin Subpages:**

* Created a new page for importing Excel files (`importExcel/page.tsx`) and added specific styling for its container. [[1]](diffhunk://#diff-f8ff5098510a37ae671a57131d3429c0f17d23c30b3031e2d7385ad2be04b2a4R1-R14) [[2]](diffhunk://#diff-f97d467bf621487e7c45f657804568347f0d88fafa0ef81b4936574e81741aeeR1-R6)
* Created a new page for managing user roles (`userRoles/page.tsx`) with its own styling. [[1]](diffhunk://#diff-382d4012a1a9fae8a8421c24a10d00efd18bd728bc03df135d806944b257fffdR1-R14) [[2]](diffhunk://#diff-d9289c2fda803401853d059aed0e9c5b9a5cb57bac909cf86aa1484a0a26aa02R1-R8)

**Other Improvements:**

* Added pagination to the main wordlist on the home page for improved navigation through large datasets.