### PR TITLE
Update footer copyright text and correct header title spelling

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -29,8 +29,7 @@ function Footer() {
             </div>
             <hr />
             <p className={style.copyright}>
-                &copy; {currentYear} Mårpeakademin - Det ligaste vi hann för den Mårpekanska
-                dialekten.
+                &copy; {currentYear} Mårpeakademien - Det ligaste vi hann.
             </p>
         </footer>
     );

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -11,7 +11,7 @@ async function Header() {
         <header className={style.header}>
             <Link href="/" className={style.logo}>
                 <Image src="/logo.svg" alt="Morpekanska Logo" width={50} height={50} />
-                <h1>Mårpeakademins orlesta</h1>
+                <h1>Mårpeakademiens orlesta</h1>
             </Link>
 
             


### PR DESCRIPTION
This pull request makes minor copy updates to the `Header` and `Footer` components to correct the spelling of "Mårpeakademien" and simplify the footer text.

- **Text and Branding Updates:**
  * [`src/components/Header/Header.tsx`](diffhunk://#diff-08f1eeca099377b71b51c70a42d155ddf8d0d6152e3961b53402a482f70c280cL14-R14): Corrected the heading to "Mårpeakademiens orlesta" for proper spelling and consistency.
  * [`src/components/Footer/Footer.tsx`](diffhunk://#diff-eaddc41bc22d344d709d06ba973003d5cb83c6dd8de442594e5ec35dba0db3fcL32-R32): Updated the footer copyright to "Mårpeakademien" and simplified the tagline.