### PR TITLE
95 fix excel import

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "db:migrate": "drizzle-kit migrate --config ./drizzle.config.ts",
         "db:generate": "drizzle-kit generate --config ./drizzle.config.ts",
         "db:seed": "tsx src/Drizzle/seed.ts",
-        "db:reset": "docker compose down -v && docker compose up -d --build && npm run db:migrate && npm run db:seed && docker compose down"
+        "db:reset": "docker compose down -v && docker compose up -d --build && npm run db:migrate && docker compose down"
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.1000.0",

--- a/src/components/Admin/ImportExcelSection.tsx
+++ b/src/components/Admin/ImportExcelSection.tsx
@@ -129,9 +129,13 @@ const ImportExcelSection = () => {
             <h2>Läs in en Excel-fil</h2>
             <hr />
             <p>
-                Se till att Excel-filen är i rätt format innan du importerar. Första
-                kolumnen ska innehålla det Morpekanska ordet och Andra kolumnen dess
-                motsvarande Översatta ordet.
+                Se till att Excel-filen är i rätt format innan du importerar.
+                <p>
+                    <strong>Första</strong> kolumnen ska innehålla det Morpekanska ordet.
+                </p>
+                <p>
+                    <strong>Andra</strong> kolumnen dess motsvarande Översatta ordet.
+                </p>
                 <br />
                 <strong>
                     [A] Morpekanska ordet

--- a/src/components/Admin/ImportExcelSection.tsx
+++ b/src/components/Admin/ImportExcelSection.tsx
@@ -61,7 +61,7 @@ const ImportExcelSection = () => {
     // Handles the import process when the user clicks the import button,
     const handleImport = async () => {
         const file = fileInput.current?.files?.[0];
-        
+
         if (!file) {
             setMessage("Välj en fil först.");
             return;
@@ -87,12 +87,10 @@ const ImportExcelSection = () => {
                     header: 1,
                 });
 
-                // Skip header row, then validate each data row.
-                const rowsToValidate = rows.slice(1).map((row) =>
-                    shouldSkipRow(row),
-                );
+                // Validate each row and determine if it should be imported or skipped.
+                const rowsToValidate = rows.map((row) => shouldSkipRow(row));
 
-                // Separate valid rows and invalid rows. 
+                // Separate valid rows and invalid rows.
                 for (const parsedRow of rowsToValidate) {
                     if (parsedRow.skip) {
                         rowsSkipped.push(parsedRow);
@@ -112,15 +110,13 @@ const ImportExcelSection = () => {
             // Create a summary of the import results to display to the user.
             const importSummary =
                 "Import klar!\n" +
-                    `\nAntal rader kontrollerade: ${rowsToImport.length + rowsSkipped.length}` +
-                    `\nAntal rader tillagda: ${rowsToImport.length}` +
-                    `\nAntal skippade: ${rowsSkipped.length}`;
+                `\nAntal rader kontrollerade: ${rowsToImport.length + rowsSkipped.length}` +
+                `\nAntal rader tillagda: ${rowsToImport.length}` +
+                `\nAntal skippade: ${rowsSkipped.length}`;
 
             setMessage(importSummary);
-
         } catch (error: unknown) {
-            const errorMessage =
-                error instanceof Error ? error.message : "Okänt fel";
+            const errorMessage = error instanceof Error ? error.message : "Okänt fel";
             setMessage("Fel vid import: " + errorMessage);
         } finally {
             sessionStorage.removeItem(EXCEL_IMPORT_IN_PROGRESS);
@@ -133,9 +129,9 @@ const ImportExcelSection = () => {
             <h2>Läs in en Excel-fil</h2>
             <hr />
             <p>
-                Se till att Excel-filen är i rätt format innan du importerar.
-                Första kolumnen ska innehålla det Morpekanska ordet och Andra
-                kolumnen dess motsvarande Översatta ordet.
+                Se till att Excel-filen är i rätt format innan du importerar. Första
+                kolumnen ska innehålla det Morpekanska ordet och Andra kolumnen dess
+                motsvarande Översatta ordet.
                 <br />
                 <strong>
                     [A] Morpekanska ordet
@@ -154,11 +150,8 @@ const ImportExcelSection = () => {
                 disabled={importLock}
                 accept=".xlsx,.xls,.csv"
                 ref={fileInput}
-                />
-            <button
-                className="btn primary"
-                onClick={handleImport}
-                disabled={importLock}>
+            />
+            <button className="btn primary" onClick={handleImport} disabled={importLock}>
                 {importLock ? "Importerar..." : "Importera Fil"}
             </button>
             {message && (


### PR DESCRIPTION
This pull request makes improvements to the Excel import functionality in the admin interface and clarifies the UI instructions. It also updates the `db:reset` script to avoid reseeding the database automatically. The main changes are grouped below:

**Excel Import Functionality and UI Improvements:**

* The row validation logic in `ImportExcelSection.tsx` now checks all rows (including the header), instead of skipping the header row, ensuring more robust validation.
* The error handling during import is simplified for clarity, and some redundant whitespace is removed.
* The UI instructions for importing an Excel file are clarified by splitting the guidance into separate paragraphs for each column, making it easier for users to understand the required format.
* Minor formatting improvements to the import button for better readability.

**Database Script Update:**

* The `db:reset` script in `package.json` is updated to remove the automatic seeding step, so it now only brings the database down, up, and runs migrations, but does not reseed by default.